### PR TITLE
Add unit tests for ScoreComponent to validate category and score display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "@angular-devkit/build-angular": "^18.2.10",
         "@angular/cli": "^18.2.10",
         "@angular/compiler-cli": "^18.2.0",
-        "@types/jasmine": "~5.1.0",
         "@types/jest": "^29.5.14",
         "jest": "^29.7.0",
         "jest-preset-angular": "^14.4.2",
@@ -5120,13 +5119,6 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
-    },
-    "node_modules/@types/jasmine": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-5.1.4.tgz",
-      "integrity": "sha512-px7OMFO/ncXxixDe1zR13V1iycqWae0MxTaw62RpFlksUi5QuNWgQJFkTQjIOvrmutJbI7Fp2Y2N1F6D2R4G6w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/jest": {
       "version": "29.5.14",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@angular-devkit/build-angular": "^18.2.10",
     "@angular/cli": "^18.2.10",
     "@angular/compiler-cli": "^18.2.0",
-    "@types/jasmine": "~5.1.0",
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",
     "jest-preset-angular": "^14.4.2",

--- a/src/app/components/category-icon/category-icon.component.spec.ts
+++ b/src/app/components/category-icon/category-icon.component.spec.ts
@@ -1,0 +1,56 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CategoryIconComponent } from './category-icon.component';
+
+describe('CategoryIconComponent', () => {
+  let component: CategoryIconComponent;
+  let fixture: ComponentFixture<CategoryIconComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CategoryIconComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CategoryIconComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should accept the input value for selectedCategory', () => {
+    component.selectedCategory = 'JavaScript';
+    fixture.detectChanges();
+    expect(component.selectedCategory).toStrictEqual(
+      expect.stringMatching(/^(HTML|CSS|JavaScript|Accessibility)$/)
+    );
+  });
+
+  it('should default to an empty string if no input is provided', () => {
+    expect(component.selectedCategory).toBe('');
+  });
+
+  // Helper function to check the rendering of the category
+  function checkCategoryRendering(category: string, expectedImageSrc: string) {
+    component.selectedCategory = category;
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement;
+    const imgElement = compiled.querySelector('img');
+    const titleElement = compiled.querySelector('h3');
+
+    expect(imgElement.src).toContain(expectedImageSrc);
+    expect(titleElement.textContent).toBe(category);
+  }
+
+  it('should display the correct HTML template for various categories', () => {
+    checkCategoryRendering('HTML', '/assets/images/icon-html.svg');
+    checkCategoryRendering('CSS', '/assets/images/icon-css.svg');
+    checkCategoryRendering('JavaScript', '/assets/images/icon-js.svg');
+    checkCategoryRendering(
+      'Accessibility',
+      '/assets/images/icon-accessibility.svg'
+    );
+  });
+});

--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -1,0 +1,42 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HomeComponent } from './home.component';
+
+describe('HomeComponent', () => {
+  let component: HomeComponent;
+  let fixture: ComponentFixture<HomeComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HomeComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HomeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should define categories array', () => {
+    expect(component.categories.length).toBe(4);
+    expect(component.categories[0].title).toBe('HTML');
+  });
+
+  it('should emit category title when onCategorySelect is called', () => {
+    const emitSpy = jest.spyOn(component.categorySelected, 'emit');
+    const category = 'JavaScript';
+    component.onCategorySelect(category);
+    expect(emitSpy).toHaveBeenCalledWith(category);
+  });
+
+  it('should render categories in the template', () => {
+    const compiled = fixture.nativeElement;
+    expect(compiled.querySelectorAll('img').length).toBe(4);
+    expect(compiled.textContent).toContain('HTML');
+    expect(compiled.textContent).toContain('CSS');
+    expect(compiled.textContent).toContain('JavaScript');
+    expect(compiled.textContent).toContain('Accessibility');
+  });
+});

--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -24,12 +24,18 @@ describe('HomeComponent', () => {
     expect(component.categories[0].title).toBe('HTML');
   });
 
-  it('should emit category title when onCategorySelect is called', () => {
-    const emitSpy = jest.spyOn(component.categorySelected, 'emit');
-    const category = 'JavaScript';
-    component.onCategorySelect(category);
-    expect(emitSpy).toHaveBeenCalledWith(category);
-  });
+
+ it('should emit category title when onCategorySelect is called', () => {
+   const emitSpy = jest.spyOn(component.categorySelected, 'emit');
+   const category = 'JavaScript';
+   component.onCategorySelect(category);
+
+   expect(emitSpy).toHaveBeenCalledWith(
+     expect.stringMatching(/^(HTML|CSS|JavaScript|Accessibility)$/)
+   );
+ });
+
+
 
   it('should render categories in the template', () => {
     const compiled = fixture.nativeElement;

--- a/src/app/components/score/score.component.spec.ts
+++ b/src/app/components/score/score.component.spec.ts
@@ -1,0 +1,72 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ScoreComponent } from './score.component';
+import { CategoryIconComponent } from '../category-icon/category-icon.component';
+import { Quiz } from '../../interfaces/quiz';
+import * as quizData from '../../../assets/data/data.json';
+import { By } from '@angular/platform-browser';
+
+describe('ScoreComponent', () => {
+  let component: ScoreComponent;
+  let fixture: ComponentFixture<ScoreComponent>;
+
+  const mockQuizzes: Quiz[] = quizData.quizzes;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ScoreComponent, CategoryIconComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ScoreComponent);
+    component = fixture.componentInstance;
+    component.selectedCategory = 'HTML';
+    component.quizzes = mockQuizzes;
+    component.correctAnswersCount = 2;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display the correct category and score', () => {
+    const categoryIcon = fixture.debugElement.query(
+      By.css('app-category-icon')
+    );
+    component.correctAnswersCount = 2;
+    fixture.detectChanges();
+
+    const score = fixture.debugElement.query(
+      By.css('.correct-score')
+    ).nativeElement;
+
+    expect(categoryIcon).toBeTruthy();
+    expect(score.textContent).toBe(`${component.correctAnswersCount}`);
+    expect(Number(score.textContent)).toBeLessThanOrEqual(10);
+  });
+
+  it('should emit quizReset event when play again button is clicked', () => {
+    jest.spyOn(component.quizReset, 'emit');
+
+    const resetButton = fixture.debugElement.query(By.css('.submit-btn'));
+    resetButton.triggerEventHandler('click', null);
+
+    expect(component.quizReset.emit).toHaveBeenCalled();
+  });
+
+  it('should display 0 as the score when no correct answers are selected', () => {
+    component.correctAnswersCount = 0;
+    fixture.detectChanges();
+
+    const score = fixture.debugElement.query(
+      By.css('.correct-score')
+    ).nativeElement;
+    const quizLength = fixture.debugElement.query(
+      By.css('.quiz-length')
+    ).nativeElement;
+
+    expect(score.textContent).toBe('0');
+    expect(quizLength.textContent).toContain(
+      mockQuizzes[0].questions.length.toString()
+    );
+  });
+});

--- a/src/app/services/quiz.service.spec.ts
+++ b/src/app/services/quiz.service.spec.ts
@@ -1,0 +1,29 @@
+import { TestBed } from '@angular/core/testing';
+import { QuizService } from './quiz.service';
+import * as quizData from '../../assets/data/data.json';
+import { Quiz } from '../interfaces/quiz';
+
+describe('QuizService', () => {
+  let service: QuizService;
+  const mockQuizData: Quiz[] = quizData.quizzes;
+
+  jest.mock('../../assets/data/data.json', () => ({
+    quizzes: mockQuizData,
+  }));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(QuizService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should return quizzes data from the JSON file', () => {
+    const quizzes = service.getQuizzes();
+    expect(quizzes).not.toBeNull();
+    expect(quizzes.length).toBe(mockQuizData.length);
+    expect(quizzes).toEqual(mockQuizData);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
   "compilerOptions": {
     "outDir": "./dist/out-tsc",
     "strict": true,
+    "resolveJsonModule": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
@@ -19,10 +20,7 @@
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",
-    "lib": [
-      "ES2022",
-      "dom"
-    ]
+    "lib": ["ES2022", "dom"]
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,


### PR DESCRIPTION
This PR adds unit tests for the ScoreComponent to ensure proper functionality in the following areas:
- Validation of the displayed category, ensuring it matches one of the predefined categories (HTML, CSS, JavaScript, Accessibility).
- Displaying the correct score based on the number of correct answers.
- Ensuring the score is set to 0 when no correct answers are selected.
- Validating that the 'Play Again' button correctly emits the `quizReset` event.
